### PR TITLE
ページ遷移は基本的に全部Backbone側でやる

### DIFF
--- a/src/client/fmushi.coffee
+++ b/src/client/fmushi.coffee
@@ -5,10 +5,91 @@ window.Fmushi =
   Scenes: {}
   Routers: {}
   Events: _.extend {}, Backbone.Events
+  fps: 24
   debug: false
   initialize: ->
-    @router = new Fmushi.Routers.App
-    Backbone.history.start pushState: true, root: '/'
+    @startAnimation()
+    @fetch()
+
+  fetch: ->
+    Fmushi.items = items = new Fmushi.Collections.Items
+    Fmushi.ranks = ranks = new Fmushi.Collections.Ranks
+
+    $.when(
+      items.fetch(),
+      ranks.fetch()
+    ).then =>
+      @router = new Fmushi.Routers.App
+      Backbone.history.start pushState: true, root: '/'
+
+  startAnimation: -> 
+    $window = $(window)
+    w = $window.width()
+    h = $window.height()
+
+    Two.Resolution = 16;
+
+    Fmushi.two = two = new Two(fullscreen: true).appendTo(document.body)
+    Fmushi.stage = stage = new PIXI.Stage 0x000000, true
+    stage.interactive = true
+
+    Fmushi.renderer = renderer = PIXI.autoDetectRenderer w, h, null, true
+    renderer.view.id = 'stage'
+    renderer.view.style.position = "absolute"
+    renderer.view.style.top  = "0"
+    renderer.view.style.left = "0"
+    document.body.appendChild renderer.view
+
+    @onResize()
+    $(window).resize _.bind(@onResize, @)
+
+    interval = 1 / @fps
+
+    getTime = @getTime
+    @startTime = lastTime = getTime()
+    @frames = 0
+
+    Events = Fmushi.Events
+    elapsed = 0
+    mainLoop = => 
+      currentTime = getTime()
+      delta = currentTime - lastTime
+      elapsed += delta
+
+      requestAnimFrame mainLoop
+      if elapsed >= interval
+        TWEEN.update()
+        two.update()
+        renderer.render stage
+        Events.trigger 'update', elapsed
+        elapsed = 0
+
+      lastTime = getTime()
+    requestAnimFrame mainLoop
+
+  getTime: -> 
+    now = window.performance && (
+      performance.now || 
+      performance.mozNow || 
+      performance.msNow || 
+      performance.oNow || 
+      performance.webkitNow );
+
+    msec = (now && now.call(performance)) || (new Date().getTime())
+    msec * 0.001
+
+  onResize: ->
+    $window = $(window)
+    w = $window.width()
+    h = $window.height()
+
+    Fmushi.renderer.resize(w, h)
+
+    @screenSize = { w: w, h: h}
+    Fmushi.Events.trigger 'resize', @screenSize
+
+  screenCenter: ->
+    { x: @screenSize.w / 2, y: @screenSize.h / 2 }
 
 class Fmushi.Vector extends Two.Vector
   toJSON: ->

--- a/src/client/routers/app.coffee
+++ b/src/client/routers/app.coffee
@@ -3,21 +3,25 @@ class Fmushi.Routers.App extends Backbone.Router
     @route ':userName', 'home'
     @route ':userName/mushies/:mushiId', 'mushi'
     @route 'signin', 'signin'
+    @route 'signup', 'signup'
 
-  startScene: (name, options={}) ->
+  replaceScene: (name, options={}) ->
     sceneClassName = name.replace /(?:^|[-_])(\w)/g, (_, c) ->
       if c? then c.toUpperCase() else ''
 
     if name isnt @currentSceneName
       Fmushi.scene?.dispose()
       Fmushi.scene = new Fmushi.Scenes[sceneClassName](options)
-      Fmushi.scene.start()
+      console.log Fmushi.scene
       @currentSceneName = name
 
   home: (userName) ->
-    @startScene 'home', userName: userName
+    @replaceScene 'home', userName: userName
 
   mushi: (userName, mushiId) ->
-    @startScene 'home', userName: userName, focusMushiId: mushiId
+    @replaceScene 'home', userName: userName, focusMushiId: mushiId
     
-  siginin: ->
+  signin: ->
+
+  signup: ->
+    

--- a/src/client/scenes/base.coffee
+++ b/src/client/scenes/base.coffee
@@ -1,82 +1,23 @@
 class Fmushi.Scenes.Base extends Fmushi.Views.Base
-  fps: 24
-  
-  start: (options={}) ->
-    $window = $(window)
-    w = $window.width()
-    h = $window.height()
+  constructor: ->
+    @$indicator = $indicator = $('#indicator').show()
 
-    Two.Resolution = 16;
+    @on 'load:complete', ->
+      $indicator.hide()
 
-    Fmushi.two = two = new Two(fullscreen: true).appendTo(document.body)
-    Fmushi.stage = stage = new PIXI.Stage 0x000000, true
-    Fmushi.stage.interactive = true
-    Fmushi.stage.interactionManager.preventDefault = false
+    @world = world = new PIXI.DisplayObjectContainer
+    Fmushi.stage.addChild world
+    @shapeWorld = shapeWorld = Fmushi.two.makeGroup()
 
-    renderer = PIXI.autoDetectRenderer w, h, null, true
-    renderer.view.id = 'stage'
-    renderer.view.style.position = "absolute"
-    renderer.view.style.top  = "0"
-    renderer.view.style.left = "0"
-    document.body.appendChild renderer.view
-    Fmushi.renderer = renderer
+    super
 
-    @onResize()
-    $(window).resize _.bind(@onResize, @)
+  onNavigate: (options) ->
 
-    Fmushi.items = items = new Fmushi.Collections.Items
-    Fmushi.ranks = ranks = new Fmushi.Collections.Ranks
+  dispose: ->
+    @$indicator.show()
 
-    $.when(
-      items.fetch(),
-      ranks.fetch()
-    ).done => @onStarted()
+    super
+    Fmushi.stage.removeChild @world
+    Fmushi.two.remove @shapeWorld    
 
-    interval = 1 / @fps
-
-    getTime = @getTime
-    @startTime = lastTime = getTime()
-    @frames = 0
-
-    Events = Fmushi.Events
-    elapsed = 0
-    mainLoop = => 
-      currentTime = getTime()
-      delta = currentTime - lastTime
-      elapsed += delta
-
-      requestAnimFrame mainLoop
-      if elapsed >= interval
-        TWEEN.update()
-        two.update()
-        renderer.render stage
-        Events.trigger 'update', elapsed
-        elapsed = 0
-
-      lastTime = getTime()
-
-    requestAnimFrame mainLoop
-
-  getTime: -> 
-    now = window.performance && (
-      performance.now || 
-      performance.mozNow || 
-      performance.msNow || 
-      performance.oNow || 
-      performance.webkitNow );
-
-    msec = (now && now.call(performance)) || (new Date().getTime())
-    msec * 0.001
-
-  onResize: ->
-    $window = $(window)
-    w = $window.width()
-    h = $window.height()
-
-    Fmushi.renderer.resize(w, h)
-
-    @screenSize = { w: w, h: h}
-    Fmushi.Events.trigger 'resize', @screenSize
-
-  screenCenter: ->
-    { x: @screenSize.w / 2, y: @screenSize.h / 2 }
+      

--- a/src/client/scenes/home.coffee
+++ b/src/client/scenes/home.coffee
@@ -29,23 +29,18 @@ class Fmushi.Scenes.Home extends Fmushi.Scenes.Base
     dialogView = new Fmushi.Views.MushiDialog
     @subview 'dialog', dialogView
 
+    @initDrag()
+    @fetch()
+
     @on 'load:complete', =>
       if options.focusMushiId?
         @focus options.focusMushiId
       else
-        center = @screenCenter()
+        center = Fmushi.screenCenter()
         @camera.set
           x: center.x
           y: center.y
           zoom: @defaultZoom
-
-  onStarted: (options) ->
-    @world = world = new PIXI.DisplayObjectContainer
-    Fmushi.stage.addChild world
-    @shapeWorld = shapeWorld = Fmushi.two.makeGroup()
-
-    @initDrag()
-    @fetch()
 
   fetch: -> 
     loaderDefer = new $.Deferred
@@ -58,7 +53,7 @@ class Fmushi.Scenes.Home extends Fmushi.Scenes.Base
 
       $.when(
         @owner.fetch(silent: true)
-        @circles.fetch(silent: true),
+        @circles.fetch(silent: true)
         @mushies.fetch(silent: true)
       ).done _.bind(@onAssetLoaded, @)
 
@@ -105,7 +100,7 @@ class Fmushi.Scenes.Home extends Fmushi.Scenes.Base
     y ?= camera.get('y')
     zoom ?= camera.get('zoom')
 
-    center = @screenCenter()
+    center = Fmushi.screenCenter()
     worldPosX = -(x * zoom - center.x)
     worldPosY = -(y * zoom - center.y)
     { x: worldPosX, y: worldPosY }
@@ -114,7 +109,7 @@ class Fmushi.Scenes.Home extends Fmushi.Scenes.Base
     if !y? and typeof x is 'object'
       y = x.y
       x = x.x
-    center  = @screenCenter()
+    center  = Fmushi.screenCenter()
     zoom    = @camera.get('zoom')
     offsetX = @camera.get('x') - (center.x / zoom)
     offsetY = @camera.get('y') - (center.y / zoom)
@@ -240,8 +235,3 @@ class Fmushi.Scenes.Home extends Fmushi.Scenes.Base
     @subview('panel').render()
 
     @trigger 'load:complete'
-
-  dispose: ->
-    super
-    Fmushi.stage.removeChild @world
-    Fmushi.two.remove @shapeWorld

--- a/src/server/app.coffee
+++ b/src/server/app.coffee
@@ -28,10 +28,8 @@ app.configure 'development', ->
   app.use express.errorHandler()
   app.use express.logger("dev")
 
-app.get '/signup',  routes.siginupForm
-app.get '/signin',  routes.signinForm
-app.post '/signup', routes.signup
-app.post '/signin', routes.signin
+app.get '/', (req, res) ->
+  res.redirect '/hadashiA'
 
 app.get '/ranks.:format?', routes.ranks.index
 app.get '/items.:format?', routes.items.index
@@ -39,10 +37,8 @@ app.get '/items.:format?', routes.items.index
 app.get '/:user.:format?',         routes.user.show
 app.get '/:user/mushies.:format?', routes.user.mushies.index
 app.get '/:user/circles.:format?', routes.user.circles.index
-app.get '/:user/*',                routes.user.show
 
-app.get '/', (req, res) ->
-  res.redirect '/hadashiA'
+app.get '/*', routes.root
 
 app.param 'format', routes.acceptOverride
 app.param 'user',   routes.user.filter

--- a/src/server/routes/index.coffee
+++ b/src/server/routes/index.coffee
@@ -15,14 +15,5 @@ module.exports =
       req.headers.accept = "application/json"
     next()
 
-  siginupForm: (req, res) ->
-    res.render 'siginup'
-
-  signinForm: (req, res) ->
-    res.render 'signin'
-
-  signup: (req, res) ->
-    res.send 'signup'
-
-  signin: (req, res) ->
-    res.send 'signin'
+  root: (req, res) ->
+    res.render 'index'

--- a/src/server/routes/user.coffee
+++ b/src/server/routes/user.coffee
@@ -6,7 +6,7 @@ exports.filter = (req, res, next, user) ->
 exports.show = (req, res) ->
   res.format
     html: ->
-      res.render 'home'
+      res.render 'index'
 
     json: ->
       res.send req.params.user

--- a/src/server/views/index.hbs
+++ b/src/server/views/index.hbs
@@ -8,3 +8,6 @@
 
 <div id="mushies-panel" class="control"></div>
 <div id="mushi-dialog-origin" class="control"></div>
+
+<script type="text/javascript" src="/js/vendor.js"></script>
+<script type="text/javascript" src="/js/app.js"></script>

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -2,8 +2,4 @@
 <meta charset="utf-8">
 <title>F虫</title>
 <link rel="stylesheet" href="/css/app.css" />
-
 {{{body}}}
-
-<script type="text/javascript" src="/js/vendor.js"></script>
-<script type="text/javascript" src="/js/app.js"></script>

--- a/src/server/views/signin.hbs
+++ b/src/server/views/signin.hbs
@@ -1,7 +1,0 @@
-<ul class="nav nav-tabs">
-  <li>
-    <a href="#email">メールアドレス</a>
-    <a href="#twitter">Twitter</a>
-    <a href="#github">Github</a>
-  </li>
-</ul>  


### PR DESCRIPTION
サーバ側でページを切り替えようとも思っていたが、やっぱりシングルページアプリケーションにする
- 主な理由
  - 読み込むjsがでかいので、jsを再読み込みしないで遷移した方が100倍はやい
  - 他のコンテンツ表示するとき、別に、ページ全体を切り替えないといけない理由がない。SEOとか意味ないし。
  - ログインフォームとか、別にページ切り替えなくても適当にポップオーバーとかで出せばいい
  - PushStateかっこいい
