### PR TITLE
sequelizeのバージョンstableなやつに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "passport": "~0.1.18",
     "passport-local": "~0.1.6",
     "passport-twitter": "~1.0.2",
-    "sequelize": "~2.0.0-beta.1",
     "pg": "~2.9.0",
-    "config": "~0.4.33"
+    "config": "~0.4.33",
+    "sequelize": "~1.7.0-rc4"
   },
   "devDependencies": {
     "cordell": "~0.1.5",


### PR DESCRIPTION
@yuua 

`./node_modules/.bin/sequelize -m`  実行したらエラー。

sequelizeのバージョンが2系になってたけど、unstableで、サイトのドキュメントとはAPIが違うらしいので、1系に変更したらマイグレーション通った。
