### PR TITLE
インデックスふりなおし

### DIFF
--- a/migrations/20140131210805-create-authentications.js
+++ b/migrations/20140131210805-create-authentications.js
@@ -23,7 +23,7 @@ module.exports = {
            indicesType: 'UNIQUE'
          }
        ).complete(done)
-    })
+   })
   },
   down: function(migration, DataTypes, done) {
     // add reverting commands here, calling 'done' when finished

--- a/migrations/20140131211746-create-equipments.js
+++ b/migrations/20140131211746-create-equipments.js
@@ -20,7 +20,7 @@ module.exports = {
         {
           indexName: 'equipmentsIndex'
         }
-        ).complete(done)
+      ).complete(done)
     })
     // add altering commands here, calling 'done' when finished
   },

--- a/migrations/20140203005206-change-items-type.js
+++ b/migrations/20140203005206-change-items-type.js
@@ -28,7 +28,7 @@ module.exports = {
       'items',
       'ItemType',
       {
-        type: DataTypes.String(128)
+        type: DataTypes.STRING(128)
       }
     ).complete(done);
   }

--- a/migrations/20140203041204-re-indexing.js
+++ b/migrations/20140203041204-re-indexing.js
@@ -1,0 +1,58 @@
+module.exports = {
+  up: function(migration, DataTypes) {
+    migration.removeIndex('authentications', 'userIdIndex');
+    migration.addIndex(
+      'authentications',
+      ['userId', 'provider'],
+      {
+        indexName: 'authentications_userId_provider',
+        indicesType: 'UNIQUE'
+      }
+    );
+
+    migration.removeIndex('equipments', 'equipmentsIndex');
+    migration.renameColumn('equipments', 'fmushiId', 'mushiId').complete(function() {
+      migration.addIndex(
+        'equipments', ['mushiId', 'itemId'],
+        {
+          indexName: 'equipments_mushiId_itemId',
+          indicesType: 'UNIQUE'
+        }
+      );
+    });
+
+    migration.removeIndex('mushies', 'mushiIndex');
+    migration.addIndex('mushies', ['userId'], { indexName: 'mushies_userId' });
+    migration.addIndex('mushies', ['rankId'], { indexName: 'mushies_rankId' });
+    migration.addIndex('mushies', ['circleId'], { indexName: 'mushies_circleId' });
+  },
+
+  down: function(migration, DataTypes) {
+    migration.removeIndex('authentications', 'authentications_userId_provider');
+    migration.addIndex(
+      'authentications', ['userId'],
+      {
+        indexName: 'userIdIndex',
+        indicesType: 'UNIQUE'
+      }
+    );
+
+    migration.removeIndex('equipments', 'equipments_mushiId_itemId');
+    migration.renameColumn('equipments', 'mushiId', 'fmushiId').complete(function() {
+      migration.addIndex(
+        'equipments',
+        ['fmushiId','itemId'],
+        { indexName: 'equipmentsIndex' }
+      );
+    });
+
+    migration.removeIndex('mushies', 'userId');
+    migration.removeIndex('mushies', 'rankId');
+    migration.removeIndex('mushies', 'circleId');
+    migration.addIndex(
+      'mushies',
+      ['userId','rankId','circleId'],
+      { indexName: 'mushiIndex' }
+    );
+  }
+}


### PR DESCRIPTION
@yuua 

以下のインデックス修正しました。
- aunthenticationsは、userIdユニークじゃない。
  - 1人のユーザが、複数のSNS認証することがあるため
- 複合インデックスになってるとこ直した。
  - たとえば、mushiesの、`[userId, rankId, circleId]` が複合インデックスになってた
- あと、インデックスの名前は、 `テーブル名_カラム名` にした。
  - 複数テーブルJOINしたSQL を EXPLAINしたとき、インデックスにテーブル名が出てないときつい
