### PR TITLE
sequezeli update 1.7の最新にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "passport-local": "~0.1.6",
     "passport-twitter": "~1.0.2",
     "pg": "~2.9.0",
-    "sequelize": "~1.7.0-rc4"
+    "sequelize": "~1.7.0"
   },
   "devDependencies": {
     "cordell": "~0.1.5",


### PR DESCRIPTION
migrationにcoffeeが使えるようになってるのでupdate

`sequelize -c --coffee` でOK
